### PR TITLE
Change main in package.json to fix require('react-address-lookup')

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-address-lookup",
   "version": "2.0.0",
   "description": "An address lookup React component.",
-  "main": "dist/index.js",
+  "main": "dist/postcode_lookup/PostcodeLookup.js",
   "scripts": {
     "start": "npm run storybook",
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
Main refers to, in package.json, dist/index.js which does not exist.

```
Welcome to Node.js v16.14.2.
Type ".help" for more information.
> require('react-address-lookup')
Uncaught:
Error: Cannot find module '/Users/aaronduce/Projects/remix-temp-address-lookup/my-remix-app/node_modules/react-address-lookup/dist/index.js'. Please verify that the package.json has a valid "main" entry
    at tryPackage (node:internal/modules/cjs/loader:353:19)
    at Function.Module._findPath (node:internal/modules/cjs/loader:566:18)
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:919:27)
    at Function.Module._load (node:internal/modules/cjs/loader:778:27)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18) {
  code: 'MODULE_NOT_FOUND',
  path: '/Users/aaronduce/Projects/remix-temp-address-lookup/my-remix-app/node_modules/react-address-lookup/package.json',
  requestPath: 'react-address-lookup'
}
> 
```

Patching this temporarily to dist/postcode_lookup/PostcodeLookup.js in my env fixes the issue to match the dist files.

![image](https://user-images.githubusercontent.com/20649108/172860645-5cd4012d-8367-4927-809b-c9b4f9c70e53.png)

If you find this sufficient, please pull this change into master and push a new dist to npm.